### PR TITLE
[AppleTV] Fix issue with react children not being rendered

### DIFF
--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1195,7 +1195,8 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     // MARK: - React View Management
 
-    func insertReactSubview(view: UIView!, atIndex: Int) {
+    override func insertReactSubview(_ view: UIView!, at atIndex: Int) {
+        super.insertReactSubview(subview, at:atIndex)
         if _controls {
             view.frame = self.bounds
             _playerViewController?.contentOverlayView?.insertSubview(view, at: atIndex)
@@ -1205,7 +1206,8 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         return
     }
 
-    func removeReactSubview(subview: UIView!) {
+    override func removeReactSubview(_ subview: UIView!) {
+        super.removeReactSubview(subview)
         if _controls {
             subview.removeFromSuperview()
         } else {

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1236,8 +1236,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
 
     // MARK: - React View Management
 
-    override func insertReactSubview(_ view: UIView!, at atIndex: Int) {
-        super.insertReactSubview(view, at:atIndex)
+    func insertReactSubview(view: UIView!, atIndex: Int) {
         if _controls {
             view.frame = self.bounds
             _playerViewController?.contentOverlayView?.insertSubview(view, at: atIndex)
@@ -1247,8 +1246,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
         return
     }
 
-    override func removeReactSubview(_ subview: UIView!) {
-        super.removeReactSubview(subview)
+    func removeReactSubview(subview: UIView!) {
         if _controls {
             subview.removeFromSuperview()
         } else {

--- a/ios/Video/RCTVideo.swift
+++ b/ios/Video/RCTVideo.swift
@@ -1237,7 +1237,7 @@ class RCTVideo: UIView, RCTVideoPlayerViewControllerDelegate, RCTPlayerObserverH
     // MARK: - React View Management
 
     override func insertReactSubview(_ view: UIView!, at atIndex: Int) {
-        super.insertReactSubview(subview, at:atIndex)
+        super.insertReactSubview(view, at:atIndex)
         if _controls {
             view.frame = self.bounds
             _playerViewController?.contentOverlayView?.insertSubview(view, at: atIndex)

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -109,6 +109,7 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
       onTextTrackDataChanged,
       onVideoTracks,
       onAspectRatio,
+      children,
       ...rest
     },
     ref,
@@ -567,9 +568,12 @@ const Video = forwardRef<VideoRef, ReactVideoProps>(
             _onReceiveAdEvent as (e: NativeSyntheticEvent<object>) => void
           }
         />
-        {showPoster ? (
-          <Image style={posterStyle} source={{uri: poster}} />
-        ) : null}
+        <>
+          {showPoster ? (
+            <Image style={posterStyle} source={{ uri: poster }} />
+          ) : null}
+          {children}
+        </>
       </View>
     );
   },


### PR DESCRIPTION
Fixes an issue where react children are never added to the native tvOS video player.

The insert/remove React view function was never triggered. This patch addresses that.